### PR TITLE
Update grd.lua

### DIFF
--- a/grd.lua
+++ b/grd.lua
@@ -278,6 +278,6 @@ function enc(n,d)
 end
 
 function cleanup()
-  m_draw:stop()
+  metro_draw:stop()
   metro.free_all()
 end


### PR DESCRIPTION
hi @yotamorimoto, just a tiny update to suppress an error in the cleanup function at line 234. thanks!
`update metro cleanup function to remove error in Maiden:  cleanup failed with error: /home/we/dust/code/grd/grd.lua:234: attempt to index a nil value (global 'm_draw')`